### PR TITLE
Update legacy-wiring-guide.md

### DIFF
--- a/electronics/legacy-wiring-guide.md
+++ b/electronics/legacy-wiring-guide.md
@@ -31,13 +31,7 @@ There are a few aspects of the [VEX Cortex](vex-electronics/vex-cortex.md) to ke
 As a result of these characteristics, a few guidelines/rules should govern port map design:
 
 * Always split the left and right side motors of a subsystem across the two PTCs. For instance, put the left side drive motors on ports 2/3, and the right side drive motors on ports 8/9. This will lessen the load on the Cortex PTCs when the subsystem is running.
-* Traditionally we like to avoid ports 1 and 10 both for consistencies sake and to keep from damaging the internal h-bridges for these ports, so use 4 y-cables when wiring a robot if possible.
-
-**The Power Expander**
-
-The [Power Expander](power-expander.md) should be used on every robot. It adds weight because of the extra battery, but the additional battery life and PTC is worth it.
-
-The power expander should power a non-crucial subsystem ideally. Obviously every part of the robot is preferable to keep on, but consider which motors would be the least crucial to lose if a power expander battery doesn't get plugged in or the power expander PTC trips. This varies from robot to robot but as a general rule, don't put the drivetrain on the power expander.
+* Using ports 1 and 10 could potentially be risky because of the risk of damaging the internal h-bridges for these ports.  This commonly occurs when the insulation of a two wire cable becomes worn and the wire inside the cable creates a short and damages the internal h-bridges of a VEX Cortex. 
 
 **Motor Controller Organization**
 


### PR DESCRIPTION
This page uses absolutes.  

Rephrased port 1 and 10 

Sections discussing the power expander was removed because it didn't contain factual information.  It appears to contain antidotal examples.  And also does not seem to discuss wiring.