### PR TITLE
Fix typo in outdated warning [vex-cortex.md]

### DIFF
--- a/electronics/vex-electronics/vex-cortex.md
+++ b/electronics/vex-electronics/vex-cortex.md
@@ -13,7 +13,7 @@ description: The VEX Cortex is the older microcontroller that was used in VRC an
 
 
 {% hint style="danger" %}
-This article is about the VEX Cortex, which is the legacy microcontroller for VRC and is no longer comp
+This article is about the VEX Cortex, which is the legacy microcontroller for VRC and is no longer competitive
 {% endhint %}
 
 The **VEX Cortex** is the older microcontroller legal for use in VRC. It is a 32-bit ARM Cortex-M3 processor with support for [PROS](../../software/vex-programming-software/pros/), [Easyc](../../software/vex-programming-software/easyc.md), and [Robotc](../../software/vex-programming-software/robotc.md). It features ten motor outputs which can deliver up to 8 A _combined_ of current \(12 A with a [VEX Power Expander](../power-expander.md)\), twelve digital inputs/outputs, eight analog inputs, and three communication interfaces.


### PR DESCRIPTION
Fixes a small typo in the [cortex page](https://wiki.purduesigbots.com/electronics/vex-electronics/vex-cortex)