### PR TITLE
Fixed traction typo in tank-drivetrain section

### DIFF
--- a/hardware/vex-drivetrains/tank-drive.md
+++ b/hardware/vex-drivetrains/tank-drive.md
@@ -8,7 +8,7 @@ Tank drives are a very popular type of drivetrain used in the VEX Robotics Compe
 
 | 4 Omni Wheels         | 6 Omni Wheels                            | 4 Omni Wheels, 2 Traction Wheels      |
 | --------------------- | ---------------------------------------- | ------------------------------------- |
-| Space efficient       | High forwards rraction                   | High forwards traction                |
+| Space efficient       | High forwards taction                   | High forwards traction                |
 | High maneuverability  | Reduces compression due to each wheel    | High horizontal traction              |
 |                       | Can add traction wheels later if desired | Reduces compression due to each wheel |
 


### PR DESCRIPTION
There's a typo in the tank drivetrain section in the table that contains the word "rraction" instead of "traction." If this is intentional, just reject the PR.