### PR TITLE
Fixed my_functions.hpp & my_functions.cpp ex. files

### DIFF
--- a/software/c++-basics-for-vex-robotics/multiple-files-c-c++.md
+++ b/software/c++-basics-for-vex-robotics/multiple-files-c-c++.md
@@ -62,6 +62,8 @@ int main() {
 #ifndef MY_FUNCTIONS_HPP
 #define MY_FUNCTIONS_HPP
 
+#include "pros/motors.hpp"
+
 void myFunction();
 
 extern pros::Motor m1; 
@@ -74,7 +76,8 @@ extern pros::Motor m1;
 #include "my_functions.hpp"
 #include <iostream>
 
-pros::Motor m1;
+std::int8_t mtr_port = 1;
+pros::Motor m1(mtr_port);
 
 void myFunction() {
   m1.move(127); 


### PR DESCRIPTION
The example my_functions.hpp now has #include "pros/motors.hpp" which is needed to compile. The example my_functions.cpp now configures the motor with a port, rather than attempting to initialize a motor with no parameters. Both of these changes are necessary to compile the example files.